### PR TITLE
Allow create files for hard links

### DIFF
--- a/download.js
+++ b/download.js
@@ -80,8 +80,7 @@ function downloadPrebuild (opts, cb) {
 
     log.info('unpacking @', cachedPrebuild)
 
-    var options =
-    {
+    var options = {
       readable: true,
       writable: true,
       hardlinkAsFilesFallback: true

--- a/download.js
+++ b/download.js
@@ -79,7 +79,17 @@ function downloadPrebuild (opts, cb) {
     }
 
     log.info('unpacking @', cachedPrebuild)
-    pump(fs.createReadStream(cachedPrebuild), zlib.createGunzip(), tfs.extract(opts.path, {readable: true, writable: true}).on('entry', updateName), function (err) {
+
+    var options =
+    {
+      readable: true,
+      writable: true,
+      allowCreateFilesForHardLinks: true
+    }
+    var extract = tfs.extract(opts.path, options).on('entry', updateName)
+
+    pump(fs.createReadStream(cachedPrebuild), zlib.createGunzip(), extract,
+    function (err) {
       if (err) return cb(err)
 
       var resolved

--- a/download.js
+++ b/download.js
@@ -84,7 +84,7 @@ function downloadPrebuild (opts, cb) {
     {
       readable: true,
       writable: true,
-      allowCreateFilesForHardLinks: true
+      hardlinkAsFilesFallback: true
     }
     var extract = tfs.extract(opts.path, options).on('entry', updateName)
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pump": "^1.0.1",
     "rc": "^1.1.6",
     "simple-get": "^2.0.0",
-    "tar-fs": "^1.12.0",
+    "tar-fs": "^1.13.0",
     "xtend": "4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Vagrant don't allow to create hard link on shared folders. This pull-request try to create a duplicate of the original file if underlying filesystem don't support hard links, like FAT does.