### PR TITLE
Electron support

### DIFF
--- a/rc.js
+++ b/rc.js
@@ -25,10 +25,11 @@ for (var j = 0; j < npmconfigs.length; ++j) {
 }
 
 var rc = module.exports = require('rc')('prebuild-install', {
-  target: process.version,
-  arch: process.arch,
+  target: process.env.npm_config_target || process.version,
+  arch: process.env.npm_config_arch || process.arch,
+  runtime: process.env.npm_config_runtime || process.title,
   platform: process.platform,
-  abi: process.versions.modules,
+  abi: process.env.npm_config_abi || process.versions.modules,
   debug: false,
   verbose: false,
   prebuild: true,
@@ -37,7 +38,9 @@ var rc = module.exports = require('rc')('prebuild-install', {
   'https-proxy': process.env['HTTPS_PROXY']
 }, minimist(process.argv, {
   alias: {
+    target: 'b',
     arch: 'a',
+    runtime: 'r',
     path: 'p',
     help: 'h',
     version: 'v',

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -12,7 +12,8 @@ test('custom config and aliases', function (t) {
     '--version',
     '--help',
     '--path ../some/other/path',
-    '--no-prebuild'
+    '--no-prebuild',
+    '--runtime RUNTIME'
   ]
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc.arch, 'ARCH', 'correct arch')
@@ -28,6 +29,7 @@ test('custom config and aliases', function (t) {
     t.equal(rc.path, '../some/other/path', 'correct path')
     t.equal(rc.path, rc.p, 'path alias')
     t.equal(rc.prebuild, false, 'correct --no-prebuild')
+    t.equal(rc.runtime, 'RUNTIME', 'correct runtime')
     t.end()
   })
 })
@@ -52,12 +54,16 @@ test('npm_config_* are passed on from environment into rc', function (t) {
   var env = {
     npm_config_proxy: 'PROXY',
     npm_config_https_proxy: 'HTTPS_PROXY',
-    npm_config_local_address: 'LOCAL_ADDRESS'
+    npm_config_local_address: 'LOCAL_ADDRESS',
+    npm_config_runtime: 'RUNTIME',
+    npm_config_target: 'TARGET'
   }
   runRc(t, '', env, function (rc) {
     t.equal(rc.proxy, 'PROXY', 'proxy is set')
     t.equal(rc['https-proxy'], 'HTTPS_PROXY', 'https-proxy is set')
     t.equal(rc['local-address'], 'LOCAL_ADDRESS', 'local-address is set')
+    t.equal(rc.target, 'TARGET', 'target is set')
+    t.equal(rc.runtime, 'RUNTIME', 'runtime is set')
     t.end()
   })
 })

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -13,15 +13,15 @@ test('prebuildCache() for different environments', function (t) {
 })
 
 test('cachedPrebuild() converts url to valid characters', function (t) {
-  var url = 'https://github.com/level/leveldown/releases/download/v1.4.0/leveldown-v1.4.0-node-v14-linux-x64.tar.gz'
-  var tail = 'https-github.com-level-leveldown-releases-download-v1.4.0-leveldown-v1.4.0-node-v14-linux-x64.tar.gz'
+  var url = 'https://github.com/level/leveldown/releases/download/v1.4.0/leveldown-v1.4.0-{runtime}-v14-linux-x64.tar.gz'
+  var tail = 'https-github.com-level-leveldown-releases-download-v1.4.0-leveldown-v1.4.0-{runtime}-v14-linux-x64.tar.gz'
   var cached = util.cachedPrebuild(url)
   t.ok(cached.indexOf(tail))
   t.end()
 })
 
 test('tempFile() ends with pid and random number', function (t) {
-  var url = 'https://github.com/level/leveldown/releases/download/v1.4.0/leveldown-v1.4.0-node-v14-linux-x64.tar.gz'
+  var url = 'https://github.com/level/leveldown/releases/download/v1.4.0/leveldown-v1.4.0-{runtime}-v14-linux-x64.tar.gz'
   var cached = util.cachedPrebuild(url)
   var tempFile = util.tempFile(cached)
   var regexp = /(\S+)\.(\d+)-([a-f0-9]+)\.tmp$/gi
@@ -42,7 +42,7 @@ test('urlTemplate() returns different templates based on pkg and rc', function (
     pkg: {binary: {host: 'http://foo.com'}}
   }
   var t2 = util.urlTemplate(o2)
-  t.equal(t2, 'http://foo.com/{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz', 'template based on pkg.binary properties')
+  t.equal(t2, 'http://foo.com/{name}-v{version}-{runtime}-v{abi}-{platform}-{arch}.tar.gz', 'template based on pkg.binary properties')
   var o3 = {
     pkg: {binary: {host: 'http://foo.com'}},
     download: true
@@ -59,32 +59,32 @@ test('urlTemplate() returns different templates based on pkg and rc', function (
     pkg: {binary: {host: 'http://foo.com', remote_path: 'w00t'}}
   }
   var t5 = util.urlTemplate(o5)
-  t.equal(t5, 'http://foo.com/w00t/{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz', 'pkg.binary.remote_path is added after host, default format')
+  t.equal(t5, 'http://foo.com/w00t/{name}-v{version}-{runtime}-v{abi}-{platform}-{arch}.tar.gz', 'pkg.binary.remote_path is added after host, default format')
   var o6 = {
     pkg: {
       binary: {
         host: 'http://foo.com',
         remote_path: 'w00t',
-        package_name: '{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz'
+        package_name: '{name}-{major}.{minor}-{runtime}-v{abi}-{platform}-{arch}.tar.gz'
       }
     }
   }
   var t6 = util.urlTemplate(o6)
-  t.equal(t6, 'http://foo.com/w00t/{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz', 'pkg.binary.package_name is added after host and remote_path, custom format')
+  t.equal(t6, 'http://foo.com/w00t/{name}-{major}.{minor}-{runtime}-v{abi}-{platform}-{arch}.tar.gz', 'pkg.binary.package_name is added after host and remote_path, custom format')
   var o7 = {pkg: require('../package.json'), download: true}
   var t7 = util.urlTemplate(o7)
-  t.equal(t7, 'https://github.com/mafintosh/prebuild-install/releases/download/v{version}/{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz', '--download with no arguments, no pkg.binary, default format')
+  t.equal(t7, 'https://github.com/mafintosh/prebuild-install/releases/download/v{version}/{name}-v{version}-{runtime}-v{abi}-{platform}-{arch}.tar.gz', '--download with no arguments, no pkg.binary, default format')
   t.end()
 })
 
 test('urlTemplate() with pkg.binary cleans up leading ./ or / and trailing /', function (t) {
-  var expected = 'http://foo.com/w00t/{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz'
+  var expected = 'http://foo.com/w00t/{name}-{major}.{minor}-{runtime}-v{abi}-{platform}-{arch}.tar.gz'
   var o = {
     pkg: {
       binary: {
         host: 'http://foo.com/',
         remote_path: '/w00t',
-        package_name: '/{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz'
+        package_name: '/{name}-{major}.{minor}-{runtime}-v{abi}-{platform}-{arch}.tar.gz'
       }
     }
   }
@@ -92,19 +92,19 @@ test('urlTemplate() with pkg.binary cleans up leading ./ or / and trailing /', f
   o.pkg.binary = {
     host: 'http://foo.com/',
     remote_path: './w00t/',
-    package_name: './{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz'
+    package_name: './{name}-{major}.{minor}-{runtime}-v{abi}-{platform}-{arch}.tar.gz'
   }
   t.equal(util.urlTemplate(o), expected)
   o.pkg.binary = {
     host: 'http://foo.com/',
     remote_path: 'w00t/',
-    package_name: '{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz/'
+    package_name: '{name}-{major}.{minor}-{runtime}-v{abi}-{platform}-{arch}.tar.gz/'
   }
   t.equal(util.urlTemplate(o), expected)
   o.pkg.binary = {
     host: 'http://foo.com',
     remote_path: './w00t',
-    package_name: '/{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz/'
+    package_name: '/{name}-{major}.{minor}-{runtime}-v{abi}-{platform}-{arch}.tar.gz/'
   }
   t.equal(util.urlTemplate(o), expected)
   t.end()

--- a/util.js
+++ b/util.js
@@ -19,7 +19,8 @@ function getDownloadUrl (opts) {
     platform: opts.platform,
     arch: opts.arch,
     configuration: (opts.debug ? 'Debug' : 'Release'),
-    module_name: opts.pkg.binary && opts.pkg.binary.module_name
+    module_name: opts.pkg.binary && opts.pkg.binary.module_name,
+    runtime: opts.runtime || 'node'
   })
 }
 
@@ -28,7 +29,7 @@ function urlTemplate (opts) {
     return opts.download
   }
 
-  var packageName = '{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz'
+  var packageName = '{name}-v{version}-{runtime}-v{abi}-{platform}-{arch}.tar.gz'
   if (opts.pkg.binary) {
     return [
       opts.pkg.binary.host,


### PR DESCRIPTION
Allows modules using `prebuild-install` (such as [mongodb-js/node-keytar](https://github.com/mongodb-js/node-keytar)) to leverage prebuild binaries when users are building electron apps. If the user has the below `.npmrc` in the root of their electron app, `prebuild-install` just works:

```
disturl=https://atom.io/download/atom-shell
target=1.2.8
runtime=electron
abi=48
```

With this PR, the logs now look like:

```
> prebuild-install -d --verbose || node-gyp rebuild
prebuild-install info begin Prebuild-install version 1.1.0
prebuild-install info looking for local prebuild @ prebuilds/keytar-v3.0.0-electron-v48-linux-x64.tar.gz
prebuild-install info looking for cached prebuild @ /home/ubuntu/.npm/_prebuilds/https-github.com-mongodb-js-node-keytar-releases-download-v3.0.0-keytar-v3.0.0-electron-v48-linux-x64.tar.gz
prebuild-install http request GET https://github.com/mongodb-js/node-keytar/releases/download/v3.0.0/keytar-v3.0.0-electron-v48-linux-x64.tar.gz
prebuild-install http 200 https://github.com/mongodb-js/node-keytar/releases/download/v3.0.0/keytar-v3.0.0-electron-v48-linux-x64.tar.gz
prebuild-install info downloading to @ /home/ubuntu/.npm/_prebuilds/https-github.com-mongodb-js-node-keytar-releases-download-v3.0.0-keytar-v3.0.0-electron-v48-linux-x64.tar.gz.11965-197065c3e219a.tmp
prebuild-install info renaming to @ /home/ubuntu/.npm/_prebuilds/https-github.com-mongodb-js-node-keytar-releases-download-v3.0.0-keytar-v3.0.0-electron-v48-linux-x64.tar.gz
prebuild-install info unpacking @ /home/ubuntu/.npm/_prebuilds/https-github.com-mongodb-js-node-keytar-releases-download-v3.0.0-keytar-v3.0.0-electron-v48-linux-x64.tar.gz
prebuild-install info unpack resolved to /data/mci/f2a6737bee2732fb1833ab8dab04ed03/src/node_modules/keytar/build/Release/keytar.node
prebuild-install info unpack required /data/mci/f2a6737bee2732fb1833ab8dab04ed03/src/node_modules/keytar/build/Release/keytar.node successfully
prebuild-install info install Prebuild successfully installed!
```