### PR TITLE
Bump node-abi@2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
     "expand-template": "^1.0.2",
     "github-from-package": "0.0.0",
     "minimist": "^1.2.0",
-    "node-abi": "^1.0.3",
+    "node-abi": "^2.0.0",
     "noop-logger": "^0.1.1",
     "npmlog": "^4.0.1",
     "os-homedir": "^1.0.1",
     "pump": "^1.0.1",
     "rc": "^1.1.6",
     "simple-get": "^1.4.2",
-    "tunnel-agent": "^0.4.3",
     "tar-fs": "^1.13.0",
+    "tunnel-agent": "^0.4.3",
     "xtend": "4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
No relevant breaking changes for `prebuild-install`. Just to receive future updates.