### PR TITLE
fix: use mkdirp for creating directories

### DIFF
--- a/download.js
+++ b/download.js
@@ -9,6 +9,7 @@ var util = require('./util')
 var error = require('./error')
 var url = require('url')
 var tunnel = require('tunnel-agent')
+var mkdirp = require('mkdirp')
 
 function downloadPrebuild (opts, cb) {
   var downloadUrl = util.getDownloadUrl(opts)
@@ -65,7 +66,7 @@ function downloadPrebuild (opts, cb) {
           if (err) return onerror(err)
           log.http(res.statusCode, downloadUrl)
           if (res.statusCode !== 200) return onerror()
-          fs.mkdir(util.prebuildCache(), function () {
+          mkdirp(util.prebuildCache(), function () {
             log.info('downloading to @', tempFile)
             pump(res, fs.createWriteStream(tempFile), function (err) {
               if (err) return onerror(err)
@@ -152,7 +153,7 @@ function downloadPrebuild (opts, cb) {
 
     function makeNpmCacheDir () {
       log.info('npm cache directory missing, creating it...')
-      fs.mkdir(cacheFolder, cb)
+      mkdirp(cacheFolder, cb)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expand-template": "^1.0.2",
     "github-from-package": "0.0.0",
     "minimist": "^1.2.0",
+    "mkdirp": "^0.5.1",
     "node-abi": "^2.0.0",
     "noop-logger": "^0.1.1",
     "npmlog": "^4.0.1",


### PR DESCRIPTION
This ensures that we can create multiple directories at once

https://github.com/electron-userland/electron-builder/issues/1415 is caused by this since it needs to create `.electron-gyp/.npm`.