### PR TITLE
make use of npm_config_cache

### DIFF
--- a/test/util-test.js
+++ b/test/util-test.js
@@ -5,10 +5,14 @@ var util = require('../util')
 var path = require('path')
 
 test('prebuildCache() for different environments', function (t) {
+  var NPMCACHE = process.env.npm_config_cache
+  delete process.env.npm_config_cache
   var APPDATA = process.env.APPDATA = 'somepathhere'
   t.equal(util.prebuildCache(), path.join(APPDATA, '/npm-cache/_prebuilds'), 'APPDATA set')
   delete process.env.APPDATA
   t.equal(util.prebuildCache(), path.join(home(), '/.npm/_prebuilds'), 'APPDATA not set')
+  process.env.npm_config_cache = NPMCACHE
+  t.equal(util.prebuildCache(), path.join(NPMCACHE, '/_prebuilds'), 'npm_config_cache set')
   t.end()
 })
 

--- a/util.js
+++ b/util.js
@@ -52,7 +52,8 @@ function cachedPrebuild (url) {
 }
 
 function npmCache () {
-  return process.env.APPDATA ? path.join(process.env.APPDATA, 'npm-cache') : path.join(home(), '.npm')
+  var env = process.env
+  return env.npm_config_cache || (env.APPDATA ? path.join(env.APPDATA, 'npm-cache') : path.join(home(), '.npm'))
 }
 
 function prebuildCache () {


### PR DESCRIPTION
This should fix #32. I left the previous implementation as a fallback, because I don't know if all npm versions set the `npm_config_cache` env variable.